### PR TITLE
HAAR-1296: ⬆️ update to java 19 and add com.nimbusds:oauth2-oidc-sdk9.41.1:…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,8 @@ dependencies {
 
   implementation(platform("com.amazonaws:aws-java-sdk-bom:1.12.434"))
 
+  implementation("com.nimbusds:oauth2-oidc-sdk:9.41.1")
+
   testImplementation("org.springframework.security:spring-security-test")
   testImplementation("com.github.tomakehurst:wiremock-standalone:2.27.2")
   testImplementation("net.javacrumbs.json-unit:json-unit-assertj:2.37.0")
@@ -52,11 +54,11 @@ dependencies {
 }
 
 java {
-  toolchain.languageVersion.set(JavaLanguageVersion.of(18))
+  toolchain.languageVersion.set(JavaLanguageVersion.of(19))
 }
 
 tasks {
   withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions.jvmTarget = "18"
+    kotlinOptions.jvmTarget = "19"
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
   implementation("org.springdoc:springdoc-openapi-data-rest:1.6.15")
 
   implementation(platform("com.amazonaws:aws-java-sdk-bom:1.12.434"))
-
+  // override version to prevent json-smart vulnerability (CVE-2023-1370)
   implementation("com.nimbusds:oauth2-oidc-sdk:9.41.1")
 
   testImplementation("org.springframework.security:spring-security-test")


### PR DESCRIPTION
… so resolve json-smart 2.4.8 vulnerability as it includes json-smart 2.4.10